### PR TITLE
Add singleton pattern for Request

### DIFF
--- a/SparkUnity/Assets/Cisco/Spark/Membership.cs
+++ b/SparkUnity/Assets/Cisco/Spark/Membership.cs
@@ -61,7 +61,7 @@ namespace Cisco.Spark {
 		/// <param name="result">Result.</param>
 		public IEnumerator Commit(Action<SparkMessage> error, Action<Membership> result) {
 			// Setup request from current state of Room object
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 
 			// Membership Data
 			var data = new Dictionary<string, string> ();
@@ -113,7 +113,7 @@ namespace Cisco.Spark {
 		/// <param name="result">Result.</param>
 		public IEnumerator Delete(Action<SparkMessage> error, Action<bool> result) {
 			if (Id != null) {
-				var manager = GameObject.FindObjectOfType<Request> ();
+				var manager = Request.Instance;
 				using (UnityWebRequest www = manager.Generate ("memberships/" + Id, UnityWebRequest.kHttpVerbDELETE)) {
 					yield return www.Send ();
 					if (www.isError) {
@@ -144,7 +144,7 @@ namespace Cisco.Spark {
 		/// <param name="personEmail">Person email.</param>
 		/// <param name="max">Max.</param>
 		public static IEnumerator ListMemberships(Action<SparkMessage> error, Action<List<Membership>> result, string roomId = null, string personId = null, string personEmail = null, int max = 0) {
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 
 			// Optional Parameters
 			var data = new Dictionary<string, string> ();
@@ -199,7 +199,7 @@ namespace Cisco.Spark {
 		/// <param name="result">Result.</param>
 		/// <param name="membershipId">Membership identifier.</param>
 		public static IEnumerator GetMembershipDetails(string membershipId, Action<SparkMessage> error, Action<Membership> result) {
-			Request manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 			using (UnityWebRequest www = manager.Generate ("memberships/" + membershipId, UnityWebRequest.kHttpVerbGET)) {
 				yield return www.Send ();
 

--- a/SparkUnity/Assets/Cisco/Spark/Message.cs
+++ b/SparkUnity/Assets/Cisco/Spark/Message.cs
@@ -82,7 +82,7 @@ namespace Cisco.Spark {
 		/// <param name="result">The created/updated Room from Spark.</param>
 		public IEnumerator Commit(Action<SparkMessage> error, Action<Message> result) {
 			// Setup request from current state of Room object
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 
 			// Message Data
 			var data = new Dictionary<string, string> ();
@@ -145,7 +145,7 @@ namespace Cisco.Spark {
 		/// <param name="result">Result.</param>
 		public IEnumerator Delete(Action<SparkMessage> error, Action<bool> result) {
 			if (Id != null) {
-				var manager = GameObject.FindObjectOfType<Request> ();
+				var manager = Request.Instance;
 				using (UnityWebRequest www = manager.Generate ("messages/" + Id, UnityWebRequest.kHttpVerbDELETE)) {
 					yield return www.Send ();
 					if (www.isError) {
@@ -172,7 +172,7 @@ namespace Cisco.Spark {
 		/// <param name="error">Error.</param>
 		/// <param name="result">Result.</param>
 		public static IEnumerator GetMessageDetails(string messageId, Action<SparkMessage> error, Action<Message> result) {
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 			using (UnityWebRequest www = manager.Generate ("messages/" + messageId, UnityWebRequest.kHttpVerbGET)) {
 				yield return www.Send ();
 				if (www.isError) {
@@ -199,7 +199,7 @@ namespace Cisco.Spark {
 		/// <param name="beforeMessage">List all messages before a specific message ID.</param>
 		/// <param name="max">Max number of messages.</param>
 		public static IEnumerator ListMessages(string roomId, Action<SparkMessage> error, Action<List<Message>> result, string before = null, string beforeMessage = null, int max = 0) {
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 			var data = new Dictionary<string, string> ();
 			data ["roomId"] = roomId;
 

--- a/SparkUnity/Assets/Cisco/Spark/Person.cs
+++ b/SparkUnity/Assets/Cisco/Spark/Person.cs
@@ -87,7 +87,7 @@ namespace Cisco.Spark {
 		/// <param name="error">Error from Spark</param>
 		/// <param name="result">Callback.</param>
 		public static IEnumerator GetPersonDetails(string personId, Action<SparkMessage> error, Action<Person> result) {
-			Request manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 			using (UnityWebRequest www = manager.Generate ("people/" + personId, UnityWebRequest.kHttpVerbGET)) {
 				yield return www.Send ();
 
@@ -122,7 +122,7 @@ namespace Cisco.Spark {
 				Debug.LogError ("Email or displayName should be specified.");
 			}
 
-			Request manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 
 			// Optional Parameters
 			var data = new Dictionary<string, string> ();

--- a/SparkUnity/Assets/Cisco/Spark/Request.cs
+++ b/SparkUnity/Assets/Cisco/Spark/Request.cs
@@ -2,9 +2,17 @@
 using UnityEngine.Networking;
 
 public class Request : MonoBehaviour {
+
+	// Singleton Request Instance
+	public static Request Instance;
+
 	// Publically Set Variables
 	public const string BaseUrl = "https://api.ciscospark.com/v1";
 	public string AuthenticationToken = "";
+
+	void Start() {
+		Instance = this;
+	}
 
 	public UnityWebRequest Generate(string resource, string requestType) {
 		// Setup Headers

--- a/SparkUnity/Assets/Cisco/Spark/Room.cs
+++ b/SparkUnity/Assets/Cisco/Spark/Room.cs
@@ -51,7 +51,7 @@ namespace Cisco.Spark {
 		/// <param name="result">The resultant Spark Room.</param>
 		public IEnumerator Commit(Action<SparkMessage> error, Action<Room> result) {
 			// Setup request from current state of Room object
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 
 			// Room Data
 			var data = new Dictionary<string, string> ();
@@ -102,7 +102,7 @@ namespace Cisco.Spark {
 		/// <param name="result">Success/Fail.</param>
 		public IEnumerator Delete(Action<SparkMessage> error, Action<bool> result) {
 			if (Id != null) {
-				var manager = GameObject.FindObjectOfType<Request> ();
+				var manager = Request.Instance;
 				using (UnityWebRequest www = manager.Generate ("rooms/" + Id, UnityWebRequest.kHttpVerbDELETE)) {
 					yield return www.Send ();
 					if (www.isError) {
@@ -132,7 +132,7 @@ namespace Cisco.Spark {
 		/// <param name="result">List of rooms.</param>
 		public static IEnumerator ListRooms(Action<SparkMessage> error, Action<List<Room>> result, string teamId = null, int max = 0, string type = null) {
 			// Build Request
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 			var data = new Dictionary<string, string> ();
 
 			// Handle optional arguments
@@ -178,7 +178,7 @@ namespace Cisco.Spark {
 		/// <param name="error">Error from Spark, if any.</param>
 		/// <param name="result">The returned Room from Spark.</param>
 		public static IEnumerator GetRoomDetails(string roomId, Action<SparkMessage> error, Action<Room> result) {
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 			using (UnityWebRequest www = manager.Generate ("rooms/" + roomId, UnityWebRequest.kHttpVerbGET)) {
 				yield return www.Send ();
 				if (www.isError) {

--- a/SparkUnity/Assets/Cisco/Spark/SparkFile.cs
+++ b/SparkUnity/Assets/Cisco/Spark/SparkFile.cs
@@ -32,7 +32,7 @@ namespace Cisco.Spark {
 		/// <param name="callback">File data as byte array</param>
 		/// <param name="forceBytes">Stops intelligent conversion of file array (e.g png -> Texture) and forces returning of a raw byte array. </param>
 		public IEnumerator Download(Action<object> callback, bool forceBytes = false) {
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 			using (UnityWebRequest www = manager.Generate ("contents/" + Id, UnityWebRequest.kHttpVerbGET)) {
 				yield return www.Send ();
 				if (www.isError) {
@@ -64,7 +64,7 @@ namespace Cisco.Spark {
 		}
 
 		public IEnumerator GetHeaders(Action<Dictionary<string, string>> callback) {
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 			using (UnityWebRequest www = manager.Generate ("contents/" + Id, UnityWebRequest.kHttpVerbHEAD)) {
 				yield return www.Send ();
 				if (www.isError) {

--- a/SparkUnity/Assets/Cisco/Spark/Team.cs
+++ b/SparkUnity/Assets/Cisco/Spark/Team.cs
@@ -38,7 +38,7 @@ namespace Cisco.Spark {
 		/// <param name="result">The created/updated <see cref="Cisco.Spark.Team"/> from Spark</param>
 		public IEnumerator Commit(Action<SparkMessage> error, Action<Team> result) {
 			// Setup request from current state of Team object
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 
 			// Only sending / updating Team Name is currently supported
 			var data = new Dictionary<string, string> ();
@@ -85,7 +85,7 @@ namespace Cisco.Spark {
 		/// <param name="result">Result.</param>
 		public IEnumerator Delete(Action<SparkMessage> error, Action<bool> result) {
 			if (Id != null) {
-				var manager = GameObject.FindObjectOfType<Request> ();
+				var manager = Request.Instance;
 				using (UnityWebRequest www = manager.Generate ("teams/" + Id, UnityWebRequest.kHttpVerbDELETE)) {
 					yield return www.Send ();
 					if (www.isError) {
@@ -113,7 +113,7 @@ namespace Cisco.Spark {
 		/// <param name="result">List of teams (callback).</param>
 		/// <param name="max">Max number of Teams to return.</param>
 		public static IEnumerator ListTeams(Action<SparkMessage> error, Action<List<Team>> result, int max = 0) {
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 
 			// Optional Parameters
 			var data = new Dictionary<string, string> ();
@@ -159,7 +159,7 @@ namespace Cisco.Spark {
 		/// <param name="result">Result.</param>
 		/// <param name="teamId">Team identifier.</param>
 		public static IEnumerator GetTeamDetails(string teamId, Action<SparkMessage> error, Action<Team> result) {
-			Request manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 			using (UnityWebRequest www = manager.Generate ("teams/" + teamId, UnityWebRequest.kHttpVerbGET)) {
 				yield return www.Send ();
 

--- a/SparkUnity/Assets/Cisco/Spark/TeamMembership.cs
+++ b/SparkUnity/Assets/Cisco/Spark/TeamMembership.cs
@@ -62,7 +62,7 @@ namespace Cisco.Spark {
 		/// <param name="error">Error.</param>
 		/// <param name="result">Result.</param>
 		public IEnumerator Commit(Action<SparkMessage> error, Action<TeamMembership> result) {
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 
 			// Membership Data
 			var data = new Dictionary<string, string> ();
@@ -114,7 +114,7 @@ namespace Cisco.Spark {
 		/// <param name="result">Result.</param>
 		public IEnumerator Delete(Action<SparkMessage> error, Action<bool> result) {
 			if (Id != null) {
-				var manager = GameObject.FindObjectOfType<Request> ();
+				var manager = Request.Instance;
 				using (UnityWebRequest www = manager.Generate ("team/memberships/" + Id, UnityWebRequest.kHttpVerbDELETE)) {
 					yield return www.Send ();
 					if (www.isError) {
@@ -145,7 +145,7 @@ namespace Cisco.Spark {
 		/// <param name="personEmail">Person email.</param>
 		/// <param name="max">Max.</param>
 		public static IEnumerator ListTeamMemberships(Action<SparkMessage> error, Action<List<TeamMembership>> result, string teamId = null, string personId = null, string personEmail = null, int max = 0) {
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 
 			// Optional Parameters
 			var data = new Dictionary<string, string> ();
@@ -200,7 +200,7 @@ namespace Cisco.Spark {
 		/// <param name="result">Result.</param>
 		/// <param name="teamMembershipId">Membership identifier.</param>
 		public static IEnumerator GetTeamMembershipDetails(string teamMembershipId, Action<SparkMessage> error, Action<TeamMembership> result) {
-			Request manager = GameObject.FindObjectOfType<Request> ();
+			Request manager = Request.Instance;
 			using (UnityWebRequest www = manager.Generate ("team/memberships/" + teamMembershipId, UnityWebRequest.kHttpVerbGET)) {
 				yield return www.Send ();
 

--- a/SparkUnity/Assets/Cisco/Spark/Webhook.cs
+++ b/SparkUnity/Assets/Cisco/Spark/Webhook.cs
@@ -74,7 +74,7 @@ namespace Cisco.Spark {
 		/// <param name="result">The created/updated Webhook from Spark (if any)</param>
 		public IEnumerator Commit(Action<SparkMessage> error, Action<Webhook> result) {
 			// Setup request from current state of Webhook object
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 
 			// Webhook Data
 			var data = new Dictionary<string, string> ();
@@ -133,7 +133,7 @@ namespace Cisco.Spark {
 		/// </summary>
 		public IEnumerator Delete(Action<SparkMessage> error, Action<bool> result) {
 			if (Id != null) {
-				var manager = GameObject.FindObjectOfType<Request> ();
+				var manager = Request.Instance;
 				using (UnityWebRequest www = manager.Generate ("webhooks/" + Id, UnityWebRequest.kHttpVerbDELETE)) {
 					yield return www.Send ();
 					if (www.isError) {
@@ -155,7 +155,7 @@ namespace Cisco.Spark {
 			
 		public static IEnumerator ListWebhooks(Action<SparkMessage> error, Action<List<Webhook>> result, string teamId = null, int max = 0, string type = null) {
 			// Build Request
-			var manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 			var data = new Dictionary<string, string> ();
 
 			// Handle optional arguments
@@ -207,7 +207,7 @@ namespace Cisco.Spark {
 		/// <param name="error">Error from Spark if any.</param>
 		/// <param name="result">Result Callback.</param>
 		public static IEnumerator GetWebhookDetails(string webhookId, Action<SparkMessage> error, Action<Webhook> result) {
-			Request manager = GameObject.FindObjectOfType<Request> ();
+			var manager = Request.Instance;
 			using (UnityWebRequest www = manager.Generate ("webhooks/" + webhookId, UnityWebRequest.kHttpVerbGET)) {
 				yield return www.Send ();
 


### PR DESCRIPTION
Adds the `Request.Instance` field for holding the single instance
of `Request`, replacing the expensive `FindObjectOfType` calls.