### PR TITLE
Fix #13

### DIFF
--- a/SparkUnity/Assets/Cisco/Spark/Request.cs
+++ b/SparkUnity/Assets/Cisco/Spark/Request.cs
@@ -10,7 +10,7 @@ public class Request : MonoBehaviour {
 	public const string BaseUrl = "https://api.ciscospark.com/v1";
 	public string AuthenticationToken = "";
 
-	void Start() {
+	void Awake() {
 		Instance = this;
 	}
 


### PR DESCRIPTION
Sets `Request.Instance` in `Request.Awake()` rather than `Request.Start()`.