### PR TITLE
Refactor Request to remove duplication

### DIFF
--- a/SparkUnity/Assets/Cisco/Spark/SparkMessage.cs
+++ b/SparkUnity/Assets/Cisco/Spark/SparkMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using UnityEngine.Networking;
 
 namespace Cisco.Spark
 {
@@ -24,11 +25,17 @@ namespace Cisco.Spark
         public string TrackingId { get; private set; }
 
         /// <summary>
+        /// The associated web request.
+        /// </summary>
+        public UnityWebRequest WebRequest {get; private set; }
+
+        /// <summary>
         /// Creates a SparkMessage from a JSON Spark response.
         /// </summary>
         /// <param name="data">Dictionary of data about the SparkMessage.</param>
-        public SparkMessage(Dictionary<string, object> data)
+        public SparkMessage(Dictionary<string, object> data, UnityWebRequest request)
         {
+            WebRequest = request;
             Message = (string)data["message"];
             Errors = new List<SparkError>();
 
@@ -44,6 +51,14 @@ namespace Cisco.Spark
                 Errors = errorList;
             }
             TrackingId = (string)data["trackingId"];
+        }
+
+        /// <summary>
+        /// Creates a SparkMessage object from a UnityWebRequest.
+        /// </summary>
+        /// <param name="statusCode">UnityWebRequest.</param>
+        public SparkMessage(UnityWebRequest request) {
+            WebRequest = request;
         }
     }
 }

--- a/SparkUnity/Assets/Cisco/Spark/SparkObject.cs
+++ b/SparkUnity/Assets/Cisco/Spark/SparkObject.cs
@@ -106,12 +106,6 @@ namespace Cisco.Spark
         /// <param name="data">Deserialised data dictionary from Spark.</param>
         protected virtual void LoadDict(Dictionary<string, object> data)
         {
-            if (data.ContainsKey("message"))
-            {
-                var message = new SparkMessage(data);
-                throw new Exception(message.Message);
-            }
-
             Id = data["id"] as string;
             Created = DateTime.Parse(data["created"] as string);
         }


### PR DESCRIPTION
Introduce new `SendRequest` method to handle sending the request
and parsing response. Also:
- SparkMessage now references the web request it is built from
for deeper inspection.
- New Request-only constructor for SparkMessage.
- More explicit exception when AuthenticationToken is empty,
fixes #19.
- Remove error checking from SparkObject.