### PR TITLE
Delete .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "SparkUnity/Assets/Cisco/Spark/Plugins/ObjLoader"]
-	branch = master
-	path = SparkUnity/Assets/Cisco/Spark/Plugins/ObjLoader
-	url = git@github.com:RichLogan/ObjLoader.git


### PR DESCRIPTION
I suspect this was causing some of my Git woes.  The ```html``` submodule's folder contained a ```.gitmodules``` file that referred to itself, causing a cyclic reference.  It is identical to the one found in ```.\arcr-unity-SparkVR\Assets\Spark```, so might've just been unintentionally duplicated.  I suspect this change needs to be made in both the ```gh-pages``` and ```master``` branches, but I defer to Rich's Git expertise.